### PR TITLE
Add bump.sh GitHub action

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,43 @@
+name: Check & deploy API documentation on Bump.sh 💙
+permissions:
+  contents: read
+  pull-requests: write
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+jobs:
+  deploy-doc:
+    if: ${{ github.event_name == 'push' }}
+    name: Deploy API documentation on Bump.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Deploy API documentation
+        uses: bump-sh/github-action@v1
+        with:
+          doc: apiplatform-test-demo
+          token: ${{secrets.BUMP_TOKEN}}
+          file: docs/openapi.json
+  api-diff:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Check API diff on Bump.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Comment pull request with API diff
+        uses: bump-sh/github-action@v1
+        with:
+          doc: apiplatform-test-demo
+          token: ${{secrets.BUMP_TOKEN}}
+          file: docs/openapi.json
+          command: diff
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Thus, API documentation should be generated on Bump.sh side, for each new commit & PR.

On Bump.sh side:
https://bump.sh/polo/docs/ab9d7259-04e5-422c-bce4-5b842129f678/settings
