### PR TITLE
Add script to persist OpenAPI  file

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -296,11 +296,11 @@
           "400": {
             "description": "Invalid input"
           },
-          "404": {
-            "description": "Resource not found"
-          },
           "422": {
             "description": "Unprocessable entity"
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "summary": "Replaces the Book resource.",
@@ -663,11 +663,11 @@
           "400": {
             "description": "Invalid input"
           },
-          "404": {
-            "description": "Resource not found"
-          },
           "422": {
             "description": "Unprocessable entity"
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "summary": "Replaces the Review resource.",
@@ -741,11 +741,11 @@
           "400": {
             "description": "Invalid input"
           },
-          "404": {
-            "description": "Resource not found"
-          },
           "422": {
             "description": "Unprocessable entity"
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "summary": "Updates the Review resource.",

--- a/docs/persist.sh
+++ b/docs/persist.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Default values
+default_url=https://localhost/docs.json
+default_output_file_path="docs/openapi.json"
+
+url="${1:-$default_url}"
+output_file_path="${2:-$default_output_file_path}"
+
+# Use curl to fetch the JSON data from the provided URL
+json_data=$(curl -s -k "$url" | jq)
+
+# Check if the curl command was successful
+if [ $? -ne 0 ]; then
+  echo "Failed to fetch JSON data from $url"
+  exit 1
+fi
+
+# Write the JSON data to the specified output file
+echo "$json_data" > "$output_file_path"
+
+# Check if the write operation was successful
+if [ $? -ne 0 ]; then
+  echo "Failed to write JSON data to $output_file_path"
+  exit 1
+fi
+
+echo "JSON data successfully copied from $url to $output_file_path"
+
+# how to use it:
+# bash docs/persist.sh "http://example.com.docs.json" "docs/test.json"
+# or with default values: bash docs/persist.sh


### PR DESCRIPTION
Run this script:
it reads locahost/docs.json, and upate docs/openapi.json if necessary.

- provide variables url or output_file_path if you need to override
- the script fetch json content of locahost/docs.json (the OpenAPI page),
with pretty-print answer `jq`

- then, this pretty JSON is saved inside docs/openapi.json

🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉

How to use it:
Each time you push a branch, run `bash docs/persist.sh`, and docs/openapi.json
will be persisted.

Then, via GitHub action, each change on this spec is received and processed
by [Bump.sh](https://bump.sh) -> Is this a breaking change?