### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,25 @@ and [Kubernetes](https://api-platform.com/docs/deployment/kubernetes).
 [![Bump.sh](https://bump.sh/packs/static/552d538eeb0cd5a2aed3.svg)](https://bump.sh)
 
 This repo has been adapted for ApiPlatform 2023 conference, to provide a live example
-About how API changelog could easily built with [Bump.sh](https://bump.sh).
+about how API changelog could easily built with [Bump.sh](https://bump.sh).
 
 API documentation demo is available here:
 https://bump.sh/demo/doc/apiplatform-test-demo
+
+API changelog follows the API contract, ie the OpenAPI specification.
+Thus, it's necessary to persist OpenAPI contract during API lifecycle.
+
+We're sure there are many ways to do it, this repo implement an example,
+based on ApiPlatform command `api:openapi:export`, and a GitHub action.
+
+1. Initialize OpenAPI specification on given path (here, 'docs/openapi.json'), by running `php bin/console api:openapi:export > docs/openapi.json` (in this repo, you can also run `bash docs/persist.sh`)
+2. Create API documentation on Bump.sh.
+3. On Bump.sh 'CI deployments' page, get API slug and token. We suggest to copy-paste GitHub action script into a new workflow (that's what we did on .github/workflows/bump.yml).
+4. Back on ApiPlatform, each time you change your API contract, persist changes in OpenAPI contact, by running `bash docs/persist.sh`
+5. On GitHub, for each deployment on a branch (new branch, or new commit, or even push --force), update OpenAPI contract too. Thus, BumP.sh add comment in PR each time a structure change is detected (for example: https://github.com/bump-sh/Api-Platform-Demo/pull/9#issuecomment-1728142508 )
+6. By merging your branch on GitHub, you API documentation is also updated. And structure change is added to [API changelog](https://bump.sh/demo/doc/apiplatform-test-demo/changes)
+
+Find more details about how to connect Bump.sh and ApiPlatform in our [getting started guides](https://docs.bump.sh/help/getting-started/api-platform/)
 
 ## More about ApiPlatform
 

--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -2,8 +2,12 @@ api_platform:
     title: Hello API Platform
     version: 1.0.0
     description: |
-      This documentation is generated from API Platform, GitHub action
-      connected to this repo: https://github.com/Polo2/my-api-demo
+      This documentation is generated from API Platform, via GitHub action
+      connected to this repo: https://github.com/bump-sh/Api-Platform-Demo.
+      More details about integration between Bump.sh and ApiPlatform [here](https://github.com/bump-sh/Api-Platform-Demo/blob/main/README.md#about-bumpsh) and [here](https://docs.bump.sh/help/getting-started/api-platform/).
+
+      Happy changelog 💙
+
     # Mercure integration, remove if unwanted
     mercure: ~
     # Good defaults for REST APIs

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "title": "Hello API Platform",
-        "description": "This documentation is generated from API Platform, GitHub action\nconnected to this repo: https://github.com/Polo2/my-api-demo",
+        "description": "This documentation is generated from API Platform, via GitHub action\nconnected to this repo: https://github.com/bump-sh/Api-Platform-Demo.\nMore details about integration between Bump.sh and ApiPlatform [here](https://github.com/bump-sh/Api-Platform-Demo/blob/main/README.md#about-bumpsh) and [here](https://docs.bump.sh/help/getting-started/api-platform/).\n\nHappy changelog \ud83d\udc99",
         "version": "1.0.0"
     },
     "servers": [


### PR DESCRIPTION
In first commit, I explain the connexion between ApiPlatform demo app (this repo) and the API changelog hosted on Bump?sh that was displayed during ApiPlatform con 2023.

In second commit, OpenAPI spec is modified with a better description (and hopefully, this is not a structural change, so no magic comment in this PR).