### PR TITLE
PR demo: Allow anonymous review

### DIFF
--- a/api/migrations/Version20231016091126.php
+++ b/api/migrations/Version20231016091126.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231016091126 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE review ALTER author DROP NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE review ALTER author SET NOT NULL');
+    }
+}

--- a/api/src/Entity/Review.php
+++ b/api/src/Entity/Review.php
@@ -34,9 +34,9 @@ class Review
     #[ORM\Column(type: 'text')]
     public string $body = '';
 
-    /** The author of the review. */
-    #[ORM\Column]
-    public string $author = '';
+    /** The author of the review (or null if comment is anonymous) */
+    #[ORM\Column(nullable: true)]
+    public ?string $author = null;
 
     /** The date of publication of this review.*/
     #[ORM\Column]

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -905,7 +905,8 @@
                         "type": "string"
                     },
                     "author": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "publicationDate": {
                         "type": "string",
@@ -969,7 +970,8 @@
                         "type": "string"
                     },
                     "author": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "publicationDate": {
                         "type": "string",


### PR DESCRIPTION
Review author is now nullable

Add nullable option from review `author` field.
    
Type went from 'string' to 'string | null',
this should not be a breaking change.
